### PR TITLE
Hide script arguments from ps and top

### DIFF
--- a/bin/larch
+++ b/bin/larch
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+$0 = 'larch' # hide arguments from ps and top
+
 require 'rubygems'
 require 'highline/import' # optional dep: termios
 require 'trollop'


### PR DESCRIPTION
This hides arguments passed to larch from showing up in utilities like `ps` and `top`
