### PR TITLE
Copy timeout

### DIFF
--- a/bin/larch
+++ b/bin/larch
@@ -40,6 +40,7 @@ EOS
     opt :expunge,          "Expunge deleted messages from the source", :short => '-x'
     opt :no_recurse,       "Don't copy subfolders recursively (cannot be used with --all or --all_subscribed)", :short => :none
     opt :sync_flags,       "Sync message flags from the source to the destination for messages that already exist at the destination", :short => '-S'
+    opt :copy_timeout,     "How long a message copy operation should run before timing out in seconds (default: 300)", :short => '-C', :default => Config::DEFAULT['copy_timeout'], :type => :string
 
     text "\nGeneral Options:"
     opt :config,           "Specify a non-default config file to use", :short => '-c', :default => Config::DEFAULT['config']

--- a/lib/larch.rb
+++ b/lib/larch.rb
@@ -5,6 +5,7 @@ require 'net/imap'
 require 'time'
 require 'uri'
 require 'yaml'
+require 'timeout'
 
 require 'sequel'
 require 'sequel/extensions/migration'
@@ -217,23 +218,31 @@ module Larch
         begin
           next unless msg = mailbox_from.peek(guid)
 
-          if msg.envelope.from
-            env_from = msg.envelope.from.first
-            from = "#{env_from.mailbox}@#{env_from.host}"
-          else
-            from = '?'
+          # When an email isn't readable it seems to hang forever with Gmail and
+          # possibly others. 5 minutes should be plenty
+          Timeout::timeout(@config['copy_timeout'].to_i) do
+            if msg.envelope.from
+              env_from = msg.envelope.from.first
+              from = "#{env_from.mailbox}@#{env_from.host}"
+            else
+              from = '?'
+            end
+
+            @log.info "[>] copying uid #{uid}: #{from} - #{msg.envelope.subject}"
+
+            mailbox_to << msg
+            @copied += 1
           end
-
-          @log.info "[>] copying uid #{uid}: #{from} - #{msg.envelope.subject}"
-
-          mailbox_to << msg
-          @copied += 1
 
           if @config['delete']
             @log.info "[<] deleting uid #{uid}"
             @deleted += 1 if mailbox_from.delete_message(guid)
           end
 
+        rescue Timeout::Error
+          @failed += 1
+          @log.error "[!!>] copying uid #{uid}: timed out!"
+          next
         rescue Larch::IMAP::Error => e
           @failed += 1
           @log.error e.message

--- a/lib/larch/config.rb
+++ b/lib/larch/config.rb
@@ -27,6 +27,7 @@ class Config
     'to-folder'        => nil, # actually INBOX; see validate()
     'to-pass'          => nil,
     'to-user'          => nil,
+    'copy-timeout'     => 300,
     'verbosity'        => 'info'
   }.freeze
 


### PR DESCRIPTION
Add a copy operation timeout. Gmail seems to hang indefinitely when it hits an "unreadable" message
