### PR TITLE
Simply added fix for a quirk I ran into with RackSpace email

### DIFF
--- a/lib/larch/imap.rb
+++ b/lib/larch/imap.rb
@@ -143,6 +143,9 @@ class IMAP
 
     # Gmail doesn't allow folders with leading or trailing whitespace.
     name.strip! if @quirks[:gmail]
+    
+    #Rackspace namespaces everything under INDEX.
+    name.sub!(/^|inbox\./i, "INBOX.") if @quirks[:rackspace] && name != 'INBOX'
 
     begin
       @mailboxes.fetch(name) do
@@ -264,6 +267,10 @@ class IMAP
     elsif host =~ /^imap(?:-ssl)?\.mail\.yahoo\.com$/
       @quirks[:yahoo] = true
       debug "looks like Yahoo! Mail"
+          
+    elsif host =~ /emailsrvr\.com/
+      @quirks[:rackspace] = true
+      debug "looks like Rackspace Mail"
     end
   end
 


### PR DESCRIPTION
RackSpace namespaces everything under INBOX, which would clause an error when trying find or create a mailbox.

``` bash
ruby-1.8.7-p352 :014 > puts imap.list('','*')
<struct Net::IMAP::MailboxList attr=[:Haschildren], delim=".", name="INBOX">
<struct Net::IMAP::MailboxList attr=[:Hasnochildren], delim=".", name="INBOX.Sent">
<struct Net::IMAP::MailboxList attr=[:Hasnochildren], delim=".", name="INBOX.ClientCommunications">
<struct Net::IMAP::MailboxList attr=[:Hasnochildren], delim=".", name="INBOX.Deleted Messages">
<struct Net::IMAP::MailboxList attr=[:Hasnochildren], delim=".", name="INBOX.Ref">
<struct Net::IMAP::MailboxList attr=[:Hasnochildren], delim=".", name="INBOX.spam">
<struct Net::IMAP::MailboxList attr=[:Hasnochildren], delim=".", name="INBOX.Trash">
<struct Net::IMAP::MailboxList attr=[:Hasnochildren], delim=".", name="INBOX.Drafts">
<struct Net::IMAP::MailboxList attr=[:Hasnochildren], delim=".", name="INBOX.Projects.AboutSpace">
```

The patch is working for me... it's running now!
